### PR TITLE
adds support for multiple Paperclip attachments using Filepicker on a single Rails model

### DIFF
--- a/lib/fileclip.rb
+++ b/lib/fileclip.rb
@@ -14,8 +14,8 @@ module FileClip
 
   class << self
 
-    def process(klass, instance_id)
-      klass.constantize.find(instance_id).process_from_filepicker
+    def process(klass, instance_id, name)
+      klass.constantize.find(instance_id).send("process_#{name}_from_filepicker")
     end
 
     # TODO: replace with checking for delayed options?
@@ -30,113 +30,96 @@ module FileClip
     def sidekiq_enabled?
       !!(defined? Sidekiq)
     end
-
-    def change_keys
-      @@change_keys ||= [:filepicker_url]
-    end
-
   end
 
   module Glue
     def self.included(base)
       base.extend ClassMethods
       base.extend FileClip::Validators::HelperMethods
-      base.send :include, InstanceMethods
     end
   end
 
   module ClassMethods
     def fileclip(name)
-      attr_accessible :filepicker_url
-      after_commit  :update_from_filepicker!
+      attr_accessible "#{name}_filepicker_url".to_sym
+      after_commit  "update_#{name}_from_filepicker!".to_sym
 
       set_fileclipped(name)
     end
 
-    def fileclipped
-      @attachment_name
-    end
-
     def set_fileclipped(name)
-      @attachment_name = name
-    end
-  end
 
-  module InstanceMethods
-
-    # TODO: can't handle multiples, just given
-    def attachment_name
-      @attachment_name ||= self.class.fileclipped
-    end
-
-    def attachment_object
-      self.send(attachment_name)
-    end
-
-    def update_from_filepicker!
-      if update_from_filepicker?
-        if FileClip.resque_enabled?
-          # TODO: self.class.name is webrick ???
-          process_with_resque!
-        elsif FileClip.sidekiq_enabled?
-          process_with_sidekiq!
-        else
-          process_from_filepicker
+      class_eval <<-RUBY
+      
+        def update_#{name}_from_filepicker!
+          if update_#{name}_from_filepicker?
+            if FileClip.resque_enabled?
+              # TODO: self.class.name is webrick ???
+              process_#{name}_with_resque!
+            elsif FileClip.sidekiq_enabled?
+              process_#{name}_with_sidekiq!
+            else
+              process_#{name}_from_filepicker
+            end
+          end
         end
-      end
-    end
+  
+        def process_#{name}_with_resque!
+          update_column(:#{name}_processing, true) if FileClip.delayed?
+          ::Resque.enqueue(FileClip::Jobs::Resque, self.class.name, self.id, :#{name})
+        end
+  
+        def process_#{name}_with_sidekiq!
+          update_column(:#{name}_processing, true) if FileClip.delayed?
+          FileClip::Jobs::Sidekiq.perform_async(self.class.name, self.id, :#{name})
+        end
+  
+        def process_#{name}_from_filepicker
+          self.class.skip_callback :commit, :after, :update_#{name}_from_filepicker!
+          self.send(:#{name}=, URI.parse(#{name}_filepicker_url))
+          self.set_#{name}_metadata
+          self.send(:#{name}).save_with_prepare_enqueueing if FileClip.delayed?
+          self.save
+          self.enqueue_delayed_processing if FileClip.delayed?
+          self.class.set_callback :commit, :after, :update_#{name}_from_filepicker!
+        end
+  
+        def set_#{name}_metadata
+          result = ::RestClient.get(#{name}_filepicker_url + "/metadata")
+          metadata = JSON.parse(result)
+  
+          self.send("#{name}_content_type=",  metadata["mimetype"])
+  
+          # Delegate to paperclips filename cleaner
+          filename = self.send(:#{name}).send(:cleanup_filename, metadata["filename"])
+          self.send(:#{name}_file_name=,     filename)
+  
+          self.send(:#{name}_file_size=,     metadata["size"])
+        end
+  
+        def update_#{name}_from_filepicker?
+          #{name}_fileclip_previously_changed? &&
+              #{name}_filepicker_url.present? &&
+              !#{name}_filepicker_only?
+        end
+  
+        def #{name}_filepicker_url_not_present?
+          return true unless self.class.column_names.include? "#{name}_filepicker_url"
+          !#{name}_filepicker_url.present?
+        end
+  
+        def #{name}_fileclip_previously_changed?
+          !(previous_changes.keys.map(&:to_sym) & [:#{name}_filepicker_url]).empty?
+        end
+  
+        # To be overridden in model if specific logic for not
+        # processing the image
+        def #{name}_filepicker_only?
+          false
+        end
 
-    def process_with_resque!
-      update_column(:"#{attachment_name}_processing", true) if FileClip.delayed?
-      ::Resque.enqueue(FileClip::Jobs::Resque, self.class.name, self.id)
-    end
-
-    def process_with_sidekiq!
-      update_column(:"#{attachment_name}_processing", true) if FileClip.delayed?
-      FileClip::Jobs::Sidekiq.perform_async(self.class.name, self.id)
-    end
-
-    def process_from_filepicker
-      self.class.skip_callback :commit, :after, :update_from_filepicker!
-      self.send(:"#{attachment_name}=", URI.parse(filepicker_url))
-      self.set_metadata
-      self.attachment_object.save_with_prepare_enqueueing if FileClip.delayed?
-      self.save
-      self.enqueue_delayed_processing if FileClip.delayed?
-      self.class.set_callback :commit, :after, :update_from_filepicker!
-    end
-
-    def set_metadata
-      metadata = JSON.parse(::RestClient.get filepicker_url + "/metadata")
-
-      self.send(:"#{attachment_name}_content_type=",  metadata["mimetype"])
-
-      # Delegate to paperclips filename cleaner
-      filename = self.attachment_object.send(:cleanup_filename, metadata["filename"])
-      self.send(:"#{attachment_name}_file_name=",     filename)
-
-      self.send(:"#{attachment_name}_file_size=",     metadata["size"])
-    end
-
-    def update_from_filepicker?
-      fileclip_previously_changed? &&
-      filepicker_url.present? &&
-      !filepicker_only?
-    end
-
-    def filepicker_url_not_present?
-      return true unless self.class.column_names.include? "filepicker_url"
-      !filepicker_url.present?
-    end
-
-    def fileclip_previously_changed?
-      !(previous_changes.keys.map(&:to_sym) & FileClip.change_keys).empty?
-    end
-
-    # To be overridden in model if specific logic for not
-    # processing the image
-    def filepicker_only?
-      false
+      RUBY
+      
     end
   end
 

--- a/lib/fileclip/action_view/helpers.rb
+++ b/lib/fileclip/action_view/helpers.rb
@@ -10,10 +10,10 @@ module FileClip
       # Options
       # js to activate it on the spot, defaults to true
       # class to add css classes
-      def link_to_fileclip(text, form_object, options={}, &block)
+      def link_to_fileclip(attachment, text, form_object, options={}, &block)
         form_object, options = text, form_object if block_given?
 
-        id = fileclip_id(form_object)
+        id = fileclip_id(attachment, form_object)
         classes = fileclip_css_classes(options[:class])
 
         # Got to be a cleaner way to do this
@@ -23,7 +23,7 @@ module FileClip
           link_to text, "javascript:void(0)", class: classes, id: id
         end
 
-        fileclip_link_builder(link, form_object, options, id)
+        fileclip_link_builder(attachment, link, form_object, options, id)
       end
 
       # Add js-fileclip to existing classes
@@ -35,10 +35,9 @@ module FileClip
       end
 
       # Object id for link
-      def fileclip_id(form_object)
+      def fileclip_id(attachment, form_object)
         new_object = form_object.object
-        attachment_name = new_object.attachment_name
-        "#{attachment_name}_#{new_object.object_id}"
+        "#{attachment}_#{new_object.object_id}"
       end
 
       # Return empty tag if it's nil or true
@@ -52,16 +51,13 @@ module FileClip
 
       # Options
       # Activate (defaults to true) to set own javascript
-      def fileclip_link_builder(link, form_object, options, id)
-        # Get attachment name
-        attachment_name = form_object.object.attachment_name
-
+      def fileclip_link_builder(attachment, link, form_object, options, id)
         js = activation(options[:js], id, options[:callback])
 
         js + link +
-        form_object.hidden_field(:filepicker_url,
+        form_object.hidden_field("#{attachment}_filepicker_url",
                                   class: "js-fileclip_url",
-                                  data: { type: attachment_name })
+                                  data: { type: attachment })
       end
 
     end

--- a/lib/fileclip/jobs/resque.rb
+++ b/lib/fileclip/jobs/resque.rb
@@ -3,8 +3,8 @@ module FileClip
     class Resque
       @queue = :fileclip
 
-      def self.perform(instance_klass, instance_id)
-        FileClip.process(instance_klass, instance_id)
+      def self.perform(instance_klass, instance_id, attachment_name)
+        FileClip.process(instance_klass, instance_id, attachment_name)
       end
     end
   end

--- a/lib/fileclip/jobs/sidekiq.rb
+++ b/lib/fileclip/jobs/sidekiq.rb
@@ -3,8 +3,8 @@ module FileClip
     class Sidekiq
       include ::Sidekiq::Worker if defined?(::Sidekiq::Worker)
 
-      def perform(instance_klass, instance_id)
-        FileClip.process(instance_klass, instance_id)
+      def perform(instance_klass, instance_id, attachment_name)
+        FileClip.process(instance_klass, instance_id, attachment_name)
       end
     end
   end

--- a/lib/fileclip/validators.rb
+++ b/lib/fileclip/validators.rb
@@ -4,7 +4,7 @@ module FileClip
     module HelperMethods
       %w{validates_attachment_content_type validates_attachment_presence validates_attachment_size}.each do |method|        
         define_method(method) do |*attr_names|
-          if self.column_names.include? "#{attr_names.first}_filepicker_url"
+          if method_defined?("#{attr_names.first}_filepicker_url".to_sym)
             attr_names.last.merge!({ :if => "#{attr_names.first}_filepicker_url_not_present?".to_sym })
           end
           super(*attr_names)

--- a/lib/fileclip/validators.rb
+++ b/lib/fileclip/validators.rb
@@ -2,20 +2,13 @@ module FileClip
   module Validators
 
     module HelperMethods
-
-      def validates_attachment_content_type(*attr_names)
-        attr_names.last.merge!({ :if => :filepicker_url_not_present? })
-        super(*attr_names)
-      end
-
-      def validates_attachment_presence(*attr_names)
-        attr_names.last.merge!({ :if => :filepicker_url_not_present? })
-        super(*attr_names)
-      end
-
-      def validates_attachment_size(*attr_names)
-        attr_names.last.merge!({ :if => :filepicker_url_not_present? })
-        super(*attr_names)
+      %w{validates_attachment_content_type validates_attachment_presence validates_attachment_size}.each do |method|        
+        define_method(method) do |*attr_names|
+          if self.column_names.include? "#{attr_names.first}_filepicker_url"
+            attr_names.last.merge!({ :if => "#{attr_names.first}_filepicker_url_not_present?".to_sym })
+          end
+          super(*attr_names)
+        end
       end
 
     end

--- a/spec/fileclip/validators_spec.rb
+++ b/spec/fileclip/validators_spec.rb
@@ -9,7 +9,7 @@ describe FileClip::Validators do
       Image._validators.clear
     end
 
-    describe "if no filepicker_url" do
+    describe "if no attachment_filepicker_url" do
       it "observes attachment presence" do
         Image.validates :attachment, :attachment_presence => true
         image.save.should be_false
@@ -31,8 +31,8 @@ describe FileClip::Validators do
 
     describe "with filepicker url" do
       before :each do
-        image.filepicker_url = "image.com"
-        image.filepicker_url_not_present?.should be_false
+        image.attachment_filepicker_url = "image.com"
+        image.attachment_filepicker_url_not_present?.should be_false
       end
 
       it "observes attachment presence" do

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -5,7 +5,13 @@ ActiveRecord::Schema.define :version => 0 do
     t.integer :attachment_updated_at
     t.integer :attachment_file_size
     t.string  :attachment_meta
-    t.string  :filepicker_url
+    t.string  :attachment_filepicker_url
+    t.string  :other_attachment_file_name
+    t.string  :other_attachment_content_type
+    t.integer :other_attachment_updated_at
+    t.integer :other_attachment_file_size
+    t.string  :other_attachment_meta
+    t.string  :other_attachment_filepicker_url
   end
 end
 
@@ -16,7 +22,7 @@ ActiveRecord::Schema.define :version => 0 do
     t.integer :attachment_updated_at
     t.integer :attachment_file_size
     t.boolean :attachment_processing, default: false
-    t.string  :filepicker_url
+    t.string  :attachment_filepicker_url
   end
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,6 +34,13 @@ class Image < ActiveRecord::Base
 
   fileclip :attachment
 
+  has_attached_file :other_attachment,
+                    :storage => :filesystem,
+                    :path => "./spec/tmp/:style/:id.:extension",
+                    :url => "./spec/tmp/:style/:id.extension"
+
+  fileclip :other_attachment
+
 end
 
 class DelayedImage < ActiveRecord::Base


### PR DESCRIPTION
We did a bit of metaprogramming in order to support multiple Filepicker-driven paperclip attachments on the same Rails model. For example:

```
class User
  has_attached_file :photo
  has_attached_file :resume
  fileclip :photo
  fileclip :resume
end
```

The only breaking change is that the `filepicker_url` column must now be renamed to prefix the attachment name (this is more consistent with the way Paperclip names the metadata columns). Using the above example, I'd add two columns in a migration:

```
def up
  add_column :users, :photo_fileclip_url
  add_column :users, :resume_fileclip_url
end
```
